### PR TITLE
Add LIMIT and TOP to queries that involve a collection in the weight controller #8

### DIFF
--- a/healthTracker/Data/INonUserRepo.cs
+++ b/healthTracker/Data/INonUserRepo.cs
@@ -2,7 +2,7 @@
 
 namespace healthTracker.Data
 {
-    public abstract class INonUserRepo
+    public abstract class INonUserRepo : IRepo
     {
         private readonly HealthTrackerContext _context;
 

--- a/healthTracker/Data/IRepo.cs
+++ b/healthTracker/Data/IRepo.cs
@@ -1,0 +1,8 @@
+﻿namespace healthTracker.Data
+{
+    public abstract class IRepo
+    {
+        public readonly int DefaultLimit = 10;
+        public readonly int DefaultOffset = 0;
+    }
+}

--- a/healthTracker/Data/IUserRepo.cs
+++ b/healthTracker/Data/IUserRepo.cs
@@ -2,14 +2,14 @@
 
 namespace healthTracker.Data
 {
-    public interface IUserRepo
+    public abstract class IUserRepo : IRepo
     {
-        public User? GetById(int id);
-        public bool EmailExists(string email);
-        public User? GetUserByEmail(string email);
-        public bool Add(User user);
-        public bool Delete(User user);
-        public bool Update(User user);
-        public bool IsValidLogin(string email, string password);
+        public abstract User? GetById(int id);
+        public abstract bool EmailExists(string email);
+        public abstract User? GetUserByEmail(string email);
+        public abstract bool Add(User user);
+        public abstract bool Delete(User user);
+        public abstract bool Update(User user);
+        public abstract bool IsValidLogin(string email, string password);
     }
 }

--- a/healthTracker/Data/UserRepo.cs
+++ b/healthTracker/Data/UserRepo.cs
@@ -10,12 +10,12 @@ namespace healthTracker.Data
             _dbContext = context;   
         }
 
-        public User? GetById(int id)
+        public override User? GetById(int id)
         {
             return _dbContext.Users.SingleOrDefault(u => u.Id == id);   
         }
 
-        public bool EmailExists(string email)
+        public override bool EmailExists(string email)
         {
             User? user = _dbContext.Users.FirstOrDefault(u => u.Email == email); 
 
@@ -24,19 +24,19 @@ namespace healthTracker.Data
             return true;
         }
 
-        public User? GetUserByEmail(string email)
+        public override User? GetUserByEmail(string email)
         {
             return _dbContext.Users.SingleOrDefault(u => u.Email == email);
         }
 
-        public bool Add(User user)
+        public override bool Add(User user)
         {
             _dbContext.Users.Add(user);
             int saveResults = _dbContext.SaveChanges();
             return saveResults > 0;
         }
         
-        public bool Delete(User user)
+        public override bool Delete(User user)
         {
             // todo delete everything with association to this user! 
             _dbContext.Remove(user);
@@ -44,14 +44,14 @@ namespace healthTracker.Data
             return saveResults > 0;
         }
 
-        public bool Update(User updatedUser)
+        public override bool Update(User updatedUser)
         {
             _dbContext.Update(updatedUser);
             int saveResults = _dbContext.SaveChanges();
             return saveResults > 0;
         }
 
-        public bool IsValidLogin(string email, string password)
+        public override bool IsValidLogin(string email, string password)
         {
             return _dbContext.Users.FirstOrDefault(u => u.Email ==email && u.Password == password) != null;
         }


### PR DESCRIPTION
- Added COUNT, OFFSET and LIMIT when querying a user's weights
- Added a default value for LIMIT and OFFSET and defined them in an abstract class that can be inherited by repo implementations 
- Had to make IUserRepo an abstract class and override functions in the UserRepo implementation 
- New behaviour, when querying, returns a json of {values:[...], count: {int: total of all available], offset: {int: of the offset}, limit: {int: of the limit}}